### PR TITLE
Rewrote the script in Python

### DIFF
--- a/dnsctl.py
+++ b/dnsctl.py
@@ -3,8 +3,7 @@
 '''
 Importing requried libraries
 '''
-from os import symlink, path, listdir, readlink, remove
-from re import match
+from os import symlink, path, readlink, remove
 from sys import exit
 import argparse
 import glob

--- a/dnsctl.py
+++ b/dnsctl.py
@@ -31,7 +31,7 @@ def get_available_dst() -> str:
 
     return ' '.join([path.basename(file).removesuffix('.resolv.conf') for file in _glob_files])
 
-def set_destination(new_dest: str):
+def set_destination(new_dest: str) -> None:
     """
     Change the '/etc/resolv.conf' link to a new destination
     """
@@ -43,7 +43,7 @@ def set_destination(new_dest: str):
         raise FileNotFoundError('Destination not found: \'{}\''.format(_target))
 
 
-def get_destination():
+def get_destination() -> None:
     """
     Print the current destination of '/etc/resolv.conf'
     """

--- a/dnsctl.py
+++ b/dnsctl.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+
+'''
+Importing requried libraries
+'''
+from os import symlink, path, listdir, readlink
+from re import match
+from sys import exit
+import argparse
+
+'''
+Defining global variables
+'''
+G_dst_dir = "/code/resolv/" # Where the destination files are stored
+G_resolv_path = "/etc/resolv.conf" # Where the 'resolv.conf' file is store on the system
+G_resolv_isLink = path.islink(G_resolv_path) # Wether the 'resolv.conf' file is already a symlink
+if G_resolv_isLink : G_init_dst = readlink(G_resolv_path) # If 'resolv.conf' is a link, the current destination
+
+'''
+This function will return a string containing the names of all available destination file
+Note the file names will get trimmed from the '.resolv.conf' that they need to have at the end
+'''
+def get_available_dst():
+    if path.exists(G_dst_dir) and path.isdir(G_dst_dir):
+        T_files = listdir(G_dst_dir)
+        T_dst = ""
+        for this_file in T_files:
+            if match('.*\.resolv\.conf', this_file):
+                if len(T_dst) == 0:
+                    T_dst += this_file.replace(".resolv.conf", "")
+                else:
+                    T_dst += " " + this_file.replace(".resolv.conf", "")
+
+        if len(T_dst) == 0:
+            exit("ERROR: No destination file available in '" + G_dst_dir + "'")
+
+        return T_dst
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(usage="%(prog)s [options]",
+                                     description="Set DNS for the whole system, or query status of current DNS configuration.")
+
+    parser.add_argument('-s', '--set',
+                        required=False,
+                        action="store_true",
+                        default=False,
+                        help="Set the DNS to a new scope (" + get_available_dst() + ")")
+
+    parser.add_argument('-g', '--get',
+                        required=False,
+                        action="store_true",
+                        default=False,
+                        help="Get the name of the currently used profile")
+
+    args = parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/dnsctl.py
+++ b/dnsctl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 '''
 Importing requried libraries

--- a/dnsctl.py
+++ b/dnsctl.py
@@ -3,7 +3,7 @@
 '''
 Importing requried libraries
 '''
-from os import symlink, path, listdir, readlink
+from os import symlink, path, listdir, readlink, remove
 from re import match
 from sys import exit
 import argparse
@@ -44,8 +44,27 @@ def set_destination(new_dest: str):
     """
     Change the '/etc/resolv.conf' link to a new destination
     """
-    print("__set config to: " + new_dest + "__")
-    exit()
+    target = G_dst_dir + new_dest + ".resolv.conf"
+    if path.exists(target):
+
+        try:
+            remove(G_resolv_path)
+        except PermissionError as error:
+            exit("ERROR: you are not allowed to change DNS")
+        except Exception as error:
+            print("Error while deleting the old link")
+            exit(error)
+            
+        try:
+            symlink(target, G_resolv_path)
+        except PermissionError as error:
+            exit("ERROR: you are not allowed to change DNS")
+        except Exception as error:
+            exit(error)
+
+        exit()
+    else:
+        exit("ERROR: '" + target + ".resolv.conf' does not exist")
 
 
 def get_destination():

--- a/dnsctl.py
+++ b/dnsctl.py
@@ -28,7 +28,7 @@ def get_available_dst() -> str:
 
     _glob_files = glob.glob(os.path.join(G_dst_dir, '*.resolv.conf'))
     if len(_glob_files) < 1:
-        raise FileNotFoundError('No destination file available in \'{}\' does not exist!'.format(G_dst_dir))
+        raise FileNotFoundError('No destination file available in \'{}\'!'.format(G_dst_dir))
 
     return ' '.join([os.path.basename(file).removesuffix('.resolv.conf') for file in _glob_files])
 

--- a/dnsctl.py
+++ b/dnsctl.py
@@ -16,11 +16,12 @@ G_resolv_path = "/etc/resolv.conf" # Where the 'resolv.conf' file is store on th
 G_resolv_isLink = path.islink(G_resolv_path) # Wether the 'resolv.conf' file is already a symlink
 if G_resolv_isLink : G_init_dst = readlink(G_resolv_path) # If 'resolv.conf' is a link, the current destination
 
-'''
-This function will return a string containing the names of all available destination file
-Note the file names will get trimmed from the '.resolv.conf' that they need to have at the end
-'''
+
 def get_available_dst():
+    '''
+    Return a string containing the names of all available destination file
+    Note the file names will get trimmed of the '.resolv.conf' that they need to have at the end
+    '''
     if path.exists(G_dst_dir) and path.isdir(G_dst_dir):
         T_files = listdir(G_dst_dir)
         T_dst = ""
@@ -35,6 +36,24 @@ def get_available_dst():
             exit("ERROR: No destination file available in '" + G_dst_dir + "'")
 
         return T_dst
+    else:
+        exit("ERROR: Directory '" + G_dst_dir + "' does not exist")
+
+
+def set_destination(new_dest: str):
+    """
+    Change the '/etc/resolv.conf' link to a new destination
+    """
+    print("__set config to: " + new_dest + "__")
+    exit()
+
+
+def get_destination():
+    """
+    Print the current destination of '/etc/resolv.conf'
+    """
+    print("DNS is set to: " + G_init_dst.replace(G_dst_dir, "").replace(".resolv.conf", ""))
+    exit()
 
 
 def main() -> None:
@@ -43,8 +62,7 @@ def main() -> None:
 
     parser.add_argument('-s', '--set',
                         required=False,
-                        action="store_true",
-                        default=False,
+                        metavar="SCOPE",
                         help="Set the DNS to a new scope (" + get_available_dst() + ")")
 
     parser.add_argument('-g', '--get',
@@ -54,6 +72,18 @@ def main() -> None:
                         help="Get the name of the currently used profile")
 
     args = parser.parse_args()
+
+    if not G_resolv_isLink:
+        print("ERROR: '" + G_resolv_path + "' is not a symlink")
+        exit()
+
+    if args.get:
+        get_destination()
+
+    if args.set:
+        set_destination(new_dest=args.set)
+
+    parser.print_help()
 
 
 if __name__ == "__main__":

--- a/dnsctl.py
+++ b/dnsctl.py
@@ -23,13 +23,13 @@ def get_available_dst() -> str:
     Note the file names will get trimmed of the '.resolv.conf' that they need to have at the end
     '''
     if not path.exists(G_dst_dir) or not path.isdir(G_dst_dir):
-        exit(f"ERROR: Directory '{G_dst_dir}' does not exist")
+        raise NotADirectoryError('Directory \'{}\' does not exist!'.format(G_dst_dir))
 
     _glob_files = glob.glob(path.join(G_dst_dir, '*.resolv.conf'))
     if len(_glob_files) < 1:
-        exit(f"ERROR: No destination file available in '{G_dst_dir}'")
-    return ' '.join([path.basename(file).removesuffix('.resolv.conf') for file in _glob_files])
+        raise FileNotFoundError('No destination file available in \'{}\' does not exist!'.format(G_dst_dir))
 
+    return ' '.join([path.basename(file).removesuffix('.resolv.conf') for file in _glob_files])
 
 def set_destination(new_dest: str):
     """
@@ -67,13 +67,23 @@ def get_destination():
 
 
 def main() -> None:
+
+    try:
+        L_available_dst = get_available_dst()
+    except NotADirectoryError as error:
+        exit(f"ERROR: Directory '{G_dst_dir}' does not exists")
+    except FileNotFoundError as error:
+        exit(f"ERROR: No destination file available in '{G_dst_dir}'")
+    except Exception as error:
+        exit(f"ERROR: {error}")
+
     parser = argparse.ArgumentParser(usage="%(prog)s [options]",
                                      description="Set DNS for the whole system, or query status of current DNS configuration.")
 
     parser.add_argument('-s', '--set',
                         required=False,
                         metavar="SCOPE",
-                        help="Set the DNS to a new scope (" + get_available_dst() + ")")
+                        help="Set the DNS to a new scope (" + L_available_dst + ")")
 
     parser.add_argument('-g', '--get',
                         required=False,

--- a/dnsctl.py
+++ b/dnsctl.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 '''
 Importing requried libraries

--- a/dnsctl.py
+++ b/dnsctl.py
@@ -62,8 +62,8 @@ def get_destination():
     """
     Print the current destination of '/etc/resolv.conf'
     """
-    print("DNS is set to: " + G_init_dst.replace(G_dst_dir, "").replace(".resolv.conf", ""))
-    exit()
+    _cur_dst = G_init_dst.replace(G_dst_dir, "").replace(".resolv.conf", "")
+    print(f"DNS is set to: {_cur_dst}")
 
 
 def main() -> None:
@@ -93,12 +93,12 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if not G_resolv_isLink:
-        print("ERROR: '" + G_resolv_path + "' is not a symlink")
-        exit()
-
     if args.get:
+        if not G_resolv_isLink:
+            exit(f"ERROR: '{G_resolv_path}' is not a symlink")
+
         get_destination()
+        return
 
     if args.set:
         set_destination(new_dest=args.set)

--- a/dnsctl.py
+++ b/dnsctl.py
@@ -18,7 +18,7 @@ G_resolv_isLink = path.islink(G_resolv_path) # Wether the 'resolv.conf' file is 
 if G_resolv_isLink : G_init_dst = readlink(G_resolv_path) # If 'resolv.conf' is a link, the current destination
 
 
-def get_available_dst():
+def get_available_dst() -> str:
     '''
     Return a string containing the names of all available destination file
     Note the file names will get trimmed of the '.resolv.conf' that they need to have at the end

--- a/dnsctl.py
+++ b/dnsctl.py
@@ -67,12 +67,14 @@ def main() -> None:
     parser = argparse.ArgumentParser(usage="%(prog)s [options]",
                                      description="Set DNS for the whole system, or query status of current DNS configuration.")
 
-    parser.add_argument('-s', '--set',
+    arg_group = parser.add_mutually_exclusive_group() # The 'set' and 'get' arguments cannot be used at the same time
+
+    arg_group.add_argument('-s', '--set',
                         required=False,
                         metavar="SCOPE",
                         help="Set the DNS to a new scope (" + L_available_dst + ")")
 
-    parser.add_argument('-g', '--get',
+    arg_group.add_argument('-g', '--get',
                         required=False,
                         action="store_true",
                         default=False,

--- a/dnsctl.py
+++ b/dnsctl.py
@@ -7,6 +7,7 @@ from os import symlink, path, listdir, readlink, remove
 from re import match
 from sys import exit
 import argparse
+import glob
 
 '''
 Defining global variables
@@ -22,22 +23,13 @@ def get_available_dst():
     Return a string containing the names of all available destination file
     Note the file names will get trimmed of the '.resolv.conf' that they need to have at the end
     '''
-    if path.exists(G_dst_dir) and path.isdir(G_dst_dir):
-        T_files = listdir(G_dst_dir)
-        T_dst = ""
-        for this_file in T_files:
-            if match('.*\.resolv\.conf', this_file):
-                if len(T_dst) == 0:
-                    T_dst += this_file.replace(".resolv.conf", "")
-                else:
-                    T_dst += " " + this_file.replace(".resolv.conf", "")
+    if not path.exists(G_dst_dir) or not path.isdir(G_dst_dir):
+        exit(f"ERROR: Directory '{G_dst_dir}' does not exist")
 
-        if len(T_dst) == 0:
-            exit("ERROR: No destination file available in '" + G_dst_dir + "'")
-
-        return T_dst
-    else:
-        exit("ERROR: Directory '" + G_dst_dir + "' does not exist")
+    _glob_files = glob.glob(path.join(G_dst_dir, '*.resolv.conf'))
+    if len(_glob_files) < 1:
+        exit(f"ERROR: No destination file available in '{G_dst_dir}'")
+    return ' '.join([path.basename(file).removesuffix('.resolv.conf') for file in _glob_files])
 
 
 def set_destination(new_dest: str):

--- a/dnsctl.py
+++ b/dnsctl.py
@@ -3,18 +3,18 @@
 '''
 Importing requried libraries
 '''
-from os import symlink, path, readlink, remove
-from sys import exit
+import os
 import argparse
 import glob
+from sys import exit
 
 '''
 Defining global variables
 '''
 G_dst_dir = "/code/resolv/" # Where the destination files are stored
 G_resolv_path = "/etc/resolv.conf" # Where the 'resolv.conf' file is store on the system
-G_resolv_isLink = path.islink(G_resolv_path) # Wether the 'resolv.conf' file is already a symlink
-if G_resolv_isLink : G_init_dst = readlink(G_resolv_path) # If 'resolv.conf' is a link, the current destination
+G_resolv_isLink = os.path.islink(G_resolv_path) # Wether the 'resolv.conf' file is already a symlink
+if G_resolv_isLink : G_init_dst = os.readlink(G_resolv_path) # If 'resolv.conf' is a link, the current destination
 
 
 def get_available_dst() -> str:
@@ -22,23 +22,24 @@ def get_available_dst() -> str:
     Return a string containing the names of all available destination file
     Note the file names will get trimmed of the '.resolv.conf' that they need to have at the end
     '''
-    if not path.exists(G_dst_dir) or not path.isdir(G_dst_dir):
+    if not os.path.exists(G_dst_dir) or not os.path.isdir(G_dst_dir):
         raise NotADirectoryError('Directory \'{}\' does not exist!'.format(G_dst_dir))
 
-    _glob_files = glob.glob(path.join(G_dst_dir, '*.resolv.conf'))
+    _glob_files = glob.glob(os.path.join(G_dst_dir, '*.resolv.conf'))
     if len(_glob_files) < 1:
         raise FileNotFoundError('No destination file available in \'{}\' does not exist!'.format(G_dst_dir))
 
-    return ' '.join([path.basename(file).removesuffix('.resolv.conf') for file in _glob_files])
+    return ' '.join([os.path.basename(file).removesuffix('.resolv.conf') for file in _glob_files])
+
 
 def set_destination(new_dest: str) -> None:
     """
     Change the '/etc/resolv.conf' link to a new destination
     """
     _target = G_dst_dir + new_dest + ".resolv.conf"
-    if path.exists(_target):
-        remove(G_resolv_path)
-        symlink(_target, G_resolv_path)
+    if os.path.exists(_target):
+        os.remove(G_resolv_path)
+        os.symlink(_target, G_resolv_path)
     else:
         raise FileNotFoundError('Destination not found: \'{}\''.format(_target))
 


### PR DESCRIPTION
The following actions that the `bash` script was able to do were ported in this Python script:
 * Get the currently used profile (via the `--get/-g` option)
 * Change the profile in use (via the `--set/-s` option)
 * Display a help message (via the `--help/-h` option ; The help message for `set` is dynamically generated to include the list of available profiles)

The following action available on the `bash` script is not ported to the Python one:
 * `status full`, which print the IP addresses of the DNS server in use

Note Python version 3.6 or higher is required to run this script

> Thanks to @WimpyMan for the help on improving this Python version